### PR TITLE
Added extra browser cache clearing to response headers when logging out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,6 +25,7 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
+    clear_site_data
     redirect_to new_session_path, notice: "You have been logged out."
   end
 
@@ -38,5 +39,9 @@ class SessionsController < ApplicationController
     return false unless params[:new_session_form].key?(:remember_me)
 
     params[:new_session_form][:remember_me] == "1"
+  end
+
+  def clear_site_data
+    response.headers["Clear-Site-Data"] = '"cache","storage"'
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -56,6 +56,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     delete session_url
 
+    assert_equal response.headers["clear-site-data"], "\"cache\",\"storage\""
     assert_redirected_to new_session_url
     assert_empty cookies[:session_id]
   end


### PR DESCRIPTION
This pull request updates the `SessionsController#destroy` method to match the updated Rails authentication generator.

Resolves #15 