### PR TITLE
Removed flash message when logging out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
   def destroy
     terminate_session
     clear_site_data
-    redirect_to new_session_path, notice: "You have been logged out."
+    redirect_to new_session_path
   end
 
   private


### PR DESCRIPTION
This pull request removes the flash message that was displayed when a user logs out (after redirected). This was moot and originally added for reasons.

Resolves #12 