### PR TITLE
Set logout redirect to root_path

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
   def destroy
     terminate_session
     clear_site_data
-    redirect_to new_session_path
+    redirect_to root_path
   end
 
   private

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -57,7 +57,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     delete session_url
 
     assert_equal response.headers["clear-site-data"], "\"cache\",\"storage\""
-    assert_redirected_to new_session_url
+    assert_redirected_to root_url
     assert_empty cookies[:session_id]
   end
 end


### PR DESCRIPTION
This pull request sets the `root_path` as the redirect path when a user logs out.

Resolves #18 