### PR TITLE
Update confirmed at upon password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -18,7 +18,7 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if @user.update(update_password_params)
+    if @user.update(update_password_params.merge(confirmed_at: Time.current))
       return redirect_to new_session_path, notice: "Your password has been reset. You may now log in."
     end
 

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -34,13 +34,14 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "a password can be updated" do
-    user = users(:one)
-
+    user = users(:confirmed)
+    old_confirmed_at = user.confirmed_at
     patch password_url(user.password_reset_token), params: { user: { password: "newpassword", password_confirmation: "newpassword" } }
 
     assert_redirected_to new_session_url
     assert_equal "Your password has been reset. You may now log in.", flash[:notice]
     assert user.reload.authenticate("newpassword")
+    assert_not_equal old_confirmed_at, user.reload.confirmed_at
   end
 
   test "a password cannot be updated with invalid token" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -43,7 +43,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create will not create a session if confirmed_at is nil" do
-    user = users(:one)
+    user = users(:unconfirmed)
     post session_url, params: { new_session_form: { email_address: user.email_address, password: "password123", remember_me: "0" } }
 
     assert_redirected_to new_session_url

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,12 +3,13 @@
 one:
   email_address: one@example.com
   password_digest: <%= password_digest %>
-
-unconfirmed:
-  email_address: unconfirmed@example.com
-  password_digest: <%= password_digest %>
+  confirmed_at: <%= Time.current %>
 
 confirmed:
   email_address: confirmed@example.com
   password_digest: <%= password_digest %>
   confirmed_at: <%= Time.current %>
+  
+unconfirmed:
+  email_address: unconfirmed@example.com
+  password_digest: <%= password_digest %>


### PR DESCRIPTION
This pull request updates a user's `confirmed_at` field when a user resets their password.

Resolves #22 