### PR TITLE
Add username to user

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -30,7 +30,7 @@ class RegistrationsController < ApplicationController
   private
 
   def create_user_params
-    params.expect(user: [ :email_address, :password, :password_confirmation ])
+    params.expect(user: [ :email_address, :username, :password, :password_confirmation ])
       .with_defaults(password_confirmation: "")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,12 +5,17 @@ class User < ApplicationRecord
   validates :email_address,
     format: { with: URI::MailTo::EMAIL_REGEXP, message: "is invalid" },
     uniqueness: { case_sensitive: true }
+  validates :username,
+    format: { with: /\A[a-zA-Z0-9]*\z/, message: "must contain only letters and numbers" },
+    uniqueness: { case_sensitive: false },
+    length: { minimum: 7, maximum: 20 }
   validates :password,
     length: { minimum: 10 },
     confirmation: true,
     if: -> { new_record? || changes[:password_digest] }
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
+  normalizes :username, with: ->(e) { e.strip }
 
   generates_token_for :email_confirmation, expires_in: 1.day do
     confirmed_at

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -12,6 +12,17 @@
     </div>
 
     <div class="mb-6">
+      <%= form.label :username, "Username" %>
+      <%= form.text_field :username, required: true, autofocus: true, autocomplete: "username", value: @user.username, class: "form-text" %>
+
+      <% if @user.errors[:username].any? %>
+        <p class="text-red-500 text-sm mt-1">
+          <%= @user.errors.full_messages_for(:username).first %>
+        </p>
+      <% end %>
+    </div>
+
+    <div class="mb-6">
       <%= form.label :password, "Password" %>
       <%= form.password_field :password, required: true, maxlength: 72, class: "form-text" %>
       

--- a/db/migrate/20250120173042_add_username_to_users.rb
+++ b/db/migrate/20250120173042_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :username, :string, null: false
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_26_200601) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_20_173042) do
   create_table "sessions", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "ip_address"
@@ -26,7 +26,9 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_26_200601) do
     t.datetime "confirmed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "sessions", "users"

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -11,6 +11,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       post registrations_url, params: {
         user: {
           email_address: "john.doe.123@example.com",
+          username: "JohnDoe123",
           password: "password123",
           password_confirmation: "password123"
         }
@@ -26,12 +27,25 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     post registrations_url, params: {
         user: {
           email_address: "john.doe.123",
+          username: "JohnDoe123",
           password: "password123",
           password_confirmation: "password123"
         }
       }
     assert_response :unprocessable_entity
     assert response.body.include?("Email address is invalid")
+  end
+
+  test "should show an error message when username is invalid" do
+    post registrations_url, params: {
+        user: {
+          email_address: "john.doe.123@example.com",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      }
+    assert_response :unprocessable_entity
+    assert response.body.include?("Username is too short (minimum is 7 characters)")
   end
 
   test "should show an error message when password is invalid" do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,14 +2,17 @@
 
 one:
   email_address: one@example.com
+  username: "UserOne123"
   password_digest: <%= password_digest %>
   confirmed_at: <%= Time.current %>
 
 confirmed:
   email_address: confirmed@example.com
+  username: "ConfirmedUser"
   password_digest: <%= password_digest %>
   confirmed_at: <%= Time.current %>
   
 unconfirmed:
   email_address: unconfirmed@example.com
+  username: "UnconfirmedUser"
   password_digest: <%= password_digest %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,47 +2,80 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   test "valid user" do
-    user = User.new(email_address: "john.doe@example.com", password: "password123")
+    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "password123")
     assert user.valid?
   end
 
   test "valid user with password_confirmation" do
-    user = User.new(email_address: "john.doe@example.com", password: "password123", password_confirmation: "password123")
+    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "password123", password_confirmation: "password123")
     assert user.valid?
   end
 
   test "email_address normalization" do
-    user = User.new(email_address: "  John.Doe@EXAMPLE.COM  \n ", password: "password123")
+    user = User.new(email_address: "  John.Doe@EXAMPLE.COM  \n ", username: "JohnDoe123", password: "password123")
     assert_equal(user.email_address, "john.doe@example.com")
   end
 
   test "email_address must be valid" do
-    user = User.new(email_address: "not.an.email", password: "password123")
+    user = User.new(email_address: "not.an.email", username: "JohnDoe123", password: "password123")
     assert_not user.valid?
     assert_equal user.errors[:email_address], [ "is invalid" ]
   end
 
   test "email_address must be unique" do
-    User.create(email_address: "John.Doe@EXAMPLE.com", password: "password123")
-    other_user = User.new(email_address: "john.doe@example.com", password: "password123")
+    User.create(email_address: "John.Doe@EXAMPLE.com", username: "JohnDoe123", password: "password123")
+    other_user = User.new(email_address: "john.doe@example.com", username: "JohnDoe345", password: "password123")
+
     assert_not other_user.valid?
     assert_equal other_user.errors[:email_address], [ "has already been taken" ]
   end
 
+  test "username must be unique" do
+    existing_user = users(:one)
+    user = User.new(email_address: "new.email.123@example.com", username: existing_user.username, password: "password123")
+
+    assert_not user.valid?
+    assert_equal user.errors[:username], [ "has already been taken" ]
+  end
+
+  test "username is case in-sensitive unique" do
+    existing_user = users(:one)
+    user = User.new(email_address: "new.email.123@example.com", username: existing_user.username.upcase, password: "password123")
+
+    assert_not user.valid?
+    assert_equal user.errors[:username], [ "has already been taken" ]
+  end
+
+  test "username must contain only letters and numbers" do
+    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123!", password: "password123")
+
+    assert_not user.valid?
+    assert_equal user.errors[:username], [ "must contain only letters and numbers" ]
+  end
+
+  test "username will be normalized to strip extra whitespace" do
+    user = User.new(email_address: "john.doe@example.com", username: "  \r\n  JohnDoe123 \n\r  ", password: "password123")
+
+    assert_equal(user.username, "JohnDoe123")
+  end
+
   test "password is required" do
-    user = User.new(email_address: "john.doe@example.com", password: "")
+    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "")
+
     assert_not user.valid?
     assert_equal user.errors[:password], [ "can't be blank", "is too short (minimum is 10 characters)" ]
   end
 
-  test "password musts be at least 10 characters" do
-    user = User.new(email_address: "john.doe@example.com", password: "aaaaaaaaa")
+  test "password must be at least 10 characters" do
+    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "aaaaaaaaa")
+
     assert_not user.valid?
     assert_equal user.errors[:password], [ "is too short (minimum is 10 characters)" ]
   end
 
   test "password must match password_confirmation" do
-    user = User.new(email_address: "john.doe@example.com", password: "password123", password_confirmation: "password456")
+    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "password123", password_confirmation: "password456")
+
     assert_not user.valid?
     assert_equal user.errors[:password_confirmation], [ "doesn't match Password" ]
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -11,18 +11,18 @@ class UserTest < ActiveSupport::TestCase
     assert user.valid?
   end
 
-  test "email address normalization" do
+  test "email_address normalization" do
     user = User.new(email_address: "  John.Doe@EXAMPLE.COM  \n ", password: "password123")
     assert_equal(user.email_address, "john.doe@example.com")
   end
 
-  test "email address must be valid" do
+  test "email_address must be valid" do
     user = User.new(email_address: "not.an.email", password: "password123")
     assert_not user.valid?
     assert_equal user.errors[:email_address], [ "is invalid" ]
   end
 
-  test "email must be unique" do
+  test "email_address must be unique" do
     User.create(email_address: "John.Doe@EXAMPLE.com", password: "password123")
     other_user = User.new(email_address: "john.doe@example.com", password: "password123")
     assert_not other_user.valid?

--- a/test/system/password_reset_test.rb
+++ b/test/system/password_reset_test.rb
@@ -5,7 +5,6 @@ class PasswordResetTest < ApplicationSystemTestCase
     visit new_password_url
 
     fill_in "Email", with: users(:confirmed).email_address
-
     click_on "Email reset instructions"
 
     assert_current_path new_session_url
@@ -18,7 +17,6 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     fill_in "New Password", with: "new_password"
     fill_in "Confirm New Password", with: "new_password"
-
     click_on "Save New Password"
 
     assert_current_path new_session_url
@@ -38,7 +36,6 @@ class PasswordResetTest < ApplicationSystemTestCase
 
     fill_in "New Password", with: "new_password"
     fill_in "Confirm New Password", with: "NOT_new_password"
-
     click_on "Save New Password"
 
     assert_current_path edit_password_url(token)

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -5,6 +5,7 @@ class RegistrationsTest < ApplicationSystemTestCase
     visit new_registration_url
 
     fill_in "Email", with: "john.doe@example.com"
+    fill_in "Username", with: "JohnDoe123"
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "password123"
 
@@ -18,6 +19,7 @@ class RegistrationsTest < ApplicationSystemTestCase
     visit new_registration_url
 
     fill_in "Email", with: "john.doe@example.com"
+    fill_in "Username", with: "JohnDoe123"
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "NOT_password123"
 
@@ -31,6 +33,7 @@ class RegistrationsTest < ApplicationSystemTestCase
     visit new_registration_url
 
     fill_in "Email", with: users(:confirmed).email_address
+    fill_in "Username", with: "JohnDoe123"
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "password123"
 
@@ -38,6 +41,19 @@ class RegistrationsTest < ApplicationSystemTestCase
 
     assert_current_path new_registration_url
     assert_text "Email address has already been taken"
+  end
+
+  test "when an existing username is used, it will display the error message" do
+    visit new_registration_url
+
+    fill_in "Email", with: "john.doe@example.com"
+    fill_in "Username", with: users(:confirmed).username
+    fill_in "Password", with: "password123"
+    fill_in "Confirm password", with: "password123"
+    click_on "Register"
+
+    assert_current_path new_registration_url
+    assert_text "Username has already been taken"
   end
 
   test "email confirmation when successfull" do


### PR DESCRIPTION
This pull request adds a `username` field to the User model.

- Adds validation to `username` on User.
- Adds `username` field to the registration form.
- Updates related tests related to Username

Resolves #11 