### PR TITLE
Change unconfirmed user experience

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -20,6 +20,6 @@
   }
 
   .alert {
-    @apply bg-red-100 text-red-800 block mb-6 p-4
+    @apply bg-red-100 text-red-800 block mb-6 p-4 shadow-sm rounded-md
   }
 }

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -59,4 +59,10 @@ module Authentication
       Current.session.destroy
       cookies.delete(:session_id)
     end
+
+    def require_email_confirmation
+      return if authenticated? && current_user.confirmed_at.present?
+
+      redirect_to profile_path, alert: "Email address not confirmed. Please check your email for a confirmation link."
+    end
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,5 +1,6 @@
 class ProfileController < ApplicationController
   layout "main"
+  before_action :require_email_confirmation, only: :update
 
   def index
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,8 +14,6 @@ class SessionsController < ApplicationController
     end
 
     if user = User.authenticate_by(new_session_params)
-      return redirect_to new_session_path, alert: "You must confirm your email before you can log in" if user.confirmed_at.nil?
-
       start_new_session_for(user, permanent: remember_me?)
       redirect_to root_url
     else

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -6,9 +6,17 @@
   <div class="col-span-3">
     <%= form_for current_user, url: profile_path do |form| %>
       <div class="mb-6">
-        <%= form.label :email_address, "Email" %>
+        <div class="flex items-center justify-between">
+          <%= form.label :email_address, "Email" %>
+
+          <% if current_user.confirmed_at.present? %>
+            <span title="<%= current_user.confirmed_at %>" class="text-gray-500 text-sm mt-1">Confirmed at <%= current_user.confirmed_at.strftime('%m/%d/%Y') %></span>
+          <% else %>
+            <span class="text-red-500 text-sm mt-1">Pending confirmation</p>
+          <% end %>
+        </div>
         <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "email", value: current_user.email_address, class: "form-text" %>
-        
+
         <% if current_user.errors[:email_address].any? %>
           <p class="text-red-500 text-sm mt-1">
             <%= current_user.errors.full_messages_for(:email_address).first %>

--- a/test/controllers/profile_controller_test.rb
+++ b/test/controllers/profile_controller_test.rb
@@ -33,4 +33,18 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
   end
+
+  test "#update requires email confirmation" do
+    user = users(:unconfirmed)
+    sign_in(user)
+    params = { user: { email_address: "different.email@example.com", username: "DifferentUsername" } }
+
+    patch profile_url, params: params
+    user.reload()
+
+    assert_redirected_to profile_url
+    assert_equal "Email address not confirmed. Please check your email for a confirmation link.", flash[:alert]
+    assert_not_equal params[:user][:username], user.username
+    assert_not_equal params[:user][:email_address], user.email_address
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -17,7 +17,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create with valid credentials and remember me" do
-    user = users(:confirmed)
+    user = users(:unconfirmed)
     post session_url, params: { new_session_form: { email_address: user.email_address, password: "password123", remember_me: "1" } }
 
     assert_redirected_to root_url
@@ -40,15 +40,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert response.parsed_body.to_html.include?("Email address is invalid")
     assert response.parsed_body.to_html.include?("Password can't be blank")
-  end
-
-  test "create will not create a session if confirmed_at is nil" do
-    user = users(:unconfirmed)
-    post session_url, params: { new_session_form: { email_address: user.email_address, password: "password123", remember_me: "0" } }
-
-    assert_redirected_to new_session_url
-    assert_nil parsed_cookies.signed[:session_id]
-    assert_equal "You must confirm your email before you can log in", flash[:alert]
   end
 
   test "destroy" do

--- a/test/system/log_in_test.rb
+++ b/test/system/log_in_test.rb
@@ -1,21 +1,7 @@
 require "application_system_test_case"
 
 class LogInTest < ApplicationSystemTestCase
-  test "a confirmed user can log in" do
-    visit new_session_url
-
-    user = users(:confirmed)
-    fill_in "Email", with: user.email_address
-    fill_in "Password", with: "password123"
-
-    click_on "Log in"
-
-    assert_current_path root_url
-    assert_text "Profile"
-    assert_text "Logout"
-  end
-
-  test "when an unconfirmed user attempts to log in, they will see an error message" do
+  test "a user can log in" do
     visit new_session_url
 
     user = users(:unconfirmed)
@@ -24,9 +10,9 @@ class LogInTest < ApplicationSystemTestCase
 
     click_on "Log in"
 
-    assert_current_path new_session_url
-
-    assert_text "You must confirm your email before you can log in"
+    assert_current_path root_url
+    assert_text "Profile"
+    assert_text "Logout"
   end
 
   test "when a invalid email or password are submitted, they will see an error message" do

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -45,4 +45,24 @@ class ProfileTest < ApplicationSystemTestCase
     assert_not_equal params[:username], user.username
     assert_not_equal params[:email_address], user.email_address
   end
+
+  test "an unconfirmed user will see 'Pending confirmation' on their profile" do
+    user = users(:unconfirmed)
+    sign_in_as(user)
+
+    visit profile_url
+
+    assert_current_path profile_url
+    assert_text "Pending confirmation"
+  end
+
+  test "a confirmed user will see email confirmation date on their profile" do
+    user = users(:one)
+    sign_in_as(user)
+
+    visit profile_url
+
+    assert_current_path profile_url
+    assert_text "Confirmed at #{user.confirmed_at.strftime('%m/%d/%Y')}"
+  end
 end

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -28,4 +28,21 @@ class ProfileTest < ApplicationSystemTestCase
     assert_text "Email address has already been taken"
     assert_text "Username must contain only letters and numbers"
   end
+
+  test "an unconfirmed user cannot update their profile" do
+    user = users(:unconfirmed)
+    params = { email_address: "different.email@example.com", username: "DifferentUsername" }
+    sign_in_as(user)
+
+    visit profile_url
+    fill_in "Email", with: params[:email_address]
+    fill_in "Username", with: params[:username]
+    click_on "Update Profile"
+    user.reload
+
+    assert_current_path profile_url
+    assert_text "Email address not confirmed. Please check your email for a confirmation link."
+    assert_not_equal params[:username], user.username
+    assert_not_equal params[:email_address], user.email_address
+  end
 end


### PR DESCRIPTION
This pull request changes the way an unconfirmed user's experience.
- A user can log in even if they do not have a confirmed account.
- A user cannot update their profile if they do not have a confirmed email.
- A user can see their email confirmation status on the profile page.

Resolves #38 