### PR TITLE
User profile password reset

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -12,10 +12,28 @@ class ProfileController < ApplicationController
     end
   end
 
+  def update_password
+    unless current_user.authenticate(params[:user][:current_password])
+      current_user.errors.add(:current_password, "is incorrect")
+      return render :index, status: :unprocessable_entity
+    end
+
+    unless current_user.update(update_password_params)
+      return render :index, status: :unprocessable_entity
+    end
+
+    redirect_to profile_path, notice: "Password updated"
+  end
+
   private
 
   def update_profile_params
     params.expect(user: [ :username, :email_address ])
       .with_defaults(username: "", email_address: "")
+  end
+
+  def update_password_params
+    params.expect(user: [ :password, :password_confirmation ])
+      .with_defaults(password: "", password_confirmation: "")
   end
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -22,6 +22,8 @@ class ProfileController < ApplicationController
       return render :index, status: :unprocessable_entity
     end
 
+    PasswordsMailer.changed(current_user).deliver_later
+
     redirect_to profile_path, notice: "Password updated"
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,7 +24,7 @@ class SessionsController < ApplicationController
   def destroy
     terminate_session
     clear_site_data
-    redirect_to root_path
+    redirect_to new_session_path
   end
 
   private

--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -3,4 +3,9 @@ class PasswordsMailer < ApplicationMailer
     @user = user
     mail subject: "Reset your password", to: user.email_address
   end
+
+  def changed(user)
+    @user = user
+    mail subject: "Password Changed", to: user.email_address
+  end
 end

--- a/app/views/passwords_mailer/changed.html.erb
+++ b/app/views/passwords_mailer/changed.html.erb
@@ -1,0 +1,3 @@
+<p>We are emailing you to let you know your password has been changed.are</p>
+
+<p>If you did not request this change, please contact us immediately.</p>

--- a/app/views/passwords_mailer/changed.text.erb
+++ b/app/views/passwords_mailer/changed.text.erb
@@ -1,0 +1,3 @@
+We are emailing you to let you know your password has been changed.are
+
+If you did not request this change, please contact us immediately.

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -31,7 +31,7 @@
 
       <div class="mb-6">
         <%= form.label :username, "Username" %>
-        <%= form.text_field :username, required: true, autofocus: false, autocomplete: "username", value: current_user.username, class: "form-text" %>
+        <%= form.text_field :username, required: true, autocomplete: "username", value: current_user.username, class: "form-text" %>
 
         <% if current_user.errors[:username].any? %>
           <p class="text-red-500 text-sm mt-1">
@@ -42,6 +42,58 @@
 
       <div class="flex items-center justify-end">
         <%= form.submit "Update Profile", class: "form-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="md:grid md:grid-cols-6 md:gap-4 p-4 sm:p-8 bg-white shadow sm:rounded-md">
+  <div class="col-span-2 mb-8 md:mb-0">
+    <h2 class="text-lg font-medium text-gray-900">
+      Change Password
+    </h2>
+    <p class="mt-1 text-sm text-gray-600">
+      Change your password.
+    </p>
+  </div>
+
+  <div class="col-span-4 lg:col-span-3">
+    <%= form_for current_user, url: profile_password_path do |form| %>
+      <div class="mb-6">
+        <%= form.label :password, "New password" %>
+        <%= form.password_field :password, required: true, class: "form-text" %>
+
+        <% if current_user.errors[:password].any? %>
+          <p class="text-red-500 text-sm mt-1">
+            <%= current_user.errors.full_messages_for(:password).first %>
+          </p>
+        <% end %>
+      </div>
+
+      <div class="mb-6">
+        <%= form.label :password_confirmation, "Confirm new password" %>
+        <%= form.password_field :password_confirmation, required: true, class: "form-text" %>
+
+        <% if current_user.errors[:password_confirmation].any? %>
+          <p class="text-red-500 text-sm mt-1">
+            <%= current_user.errors.full_messages_for(:password_confirmation).first %>
+          </p>
+        <% end %>
+      </div>
+
+      <div class="mb-6">
+        <%= form.label :current_password, "Current password" %>
+        <%= form.password_field :current_password, required: true, class: "form-text" %>
+
+        <% if current_user.errors[:current_password].any? %>
+          <p class="text-red-500 text-sm mt-1">
+            <%= current_user.errors.full_messages_for(:current_password).first %>
+          </p>
+        <% end %>
+      </div>
+
+      <div class="flex items-center justify-end">
+        <%= form.submit "Change Password", class: "form-button" %>
       </div>
     <% end %>
   </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   routes.default_url_options[:host] = "example.com"
+
+  # Set the minimum cost for BCrypt.
+  BCrypt::Engine.cost = BCrypt::Engine::MIN_COST
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   get "profile" => "profile#index", as: :profile
   patch "profile" => "profile#update"
+  patch "profile/password" => "profile#update_password", as: :profile_password
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,12 +3,12 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
 
-  def sign_in_as(user)
+  def sign_in_as(user, password: "password123")
+    user = users(user) unless user.is_a? User
+
     visit new_session_url
-
     fill_in "Email", with: user.email_address
-    fill_in "Password", with: "password123"
-
+    fill_in "Password", with: password
     click_on "Log in"
 
     assert_current_path root_url

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class HomeControllerTest < ActionDispatch::IntegrationTest
   test "the home page exists" do
     get root_url
+
     assert_response :success
   end
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -8,7 +8,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "an email can be submitted for password reset" do
-    user = users(:one)
+    user = users(:confirmed)
 
     assert_emails 1 do
       post passwords_url, params: { email_address: user.email_address }
@@ -26,7 +26,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get edit" do
-    user = users(:one)
+    user = users(:confirmed)
 
     get edit_password_url(user.password_reset_token)
 
@@ -36,6 +36,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   test "a password can be updated" do
     user = users(:confirmed)
     old_confirmed_at = user.confirmed_at
+
     patch password_url(user.password_reset_token), params: { user: { password: "newpassword", password_confirmation: "newpassword" } }
 
     assert_redirected_to new_session_url
@@ -45,7 +46,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "a password cannot be updated with invalid token" do
-    user = users(:one)
+    user = users(:confirmed)
 
     patch password_url("invalidtoken"), params: { user: { password: "newpassword", password_confirmation: "newpassword" } }
 
@@ -55,7 +56,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "the password field will display error message if invalid" do
-    user = users(:one)
+    user = users(:confirmed)
 
     patch password_url(user.password_reset_token), params: { user: { password: "123123", password_confirmation: "newpassword" } }
 
@@ -64,7 +65,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "password confirmation will display error message if invalid" do
-    user = users(:one)
+    user = users(:confirmed)
 
     patch password_url(user.password_reset_token), params: { user: { password: "newpassword", password_confirmation: "newpassword2" } }
 

--- a/test/controllers/profile_controller_test.rb
+++ b/test/controllers/profile_controller_test.rb
@@ -51,7 +51,9 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
     params = { user: { password: "newpassword", password_confirmation: "newpassword", current_password: "password123" } }
 
     sign_in_as(user)
-    patch profile_password_url, params: params
+    assert_enqueued_emails 1 do
+      patch profile_password_url, params: params
+    end
 
     assert_redirected_to profile_url
     assert_equal "Password updated", flash[:notice]

--- a/test/controllers/profile_controller_test.rb
+++ b/test/controllers/profile_controller_test.rb
@@ -2,8 +2,7 @@ require "test_helper"
 
 class ProfileControllerTest < ActionDispatch::IntegrationTest
   test "#index exists" do
-    user = users(:one)
-    sign_in(user)
+    sign_in_as(:confirmed)
 
     get profile_url
 
@@ -11,10 +10,10 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#update updates the user" do
-    user = users(:one)
-    sign_in(user)
+    user = users(:confirmed)
     params = { user: { username: "newusername", email_address: "new.email@example.com" } }
 
+    sign_in_as(user)
     patch profile_url, params: params
     user.reload
 
@@ -25,10 +24,9 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#update with render :index when user is invalid" do
-    user = users(:one)
-    sign_in(user)
     params = { user: { email_address: "new.email@example.com" } }
 
+    sign_in_as(:confirmed)
     patch profile_url, params: params
 
     assert_response :unprocessable_entity
@@ -36,9 +34,9 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
 
   test "#update requires email confirmation" do
     user = users(:unconfirmed)
-    sign_in(user)
     params = { user: { email_address: "different.email@example.com", username: "DifferentUsername" } }
 
+    sign_in_as(user)
     patch profile_url, params: params
     user.reload()
 
@@ -46,5 +44,39 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Email address not confirmed. Please check your email for a confirmation link.", flash[:alert]
     assert_not_equal params[:user][:username], user.username
     assert_not_equal params[:user][:email_address], user.email_address
+  end
+
+  test "#update_password updates the user's password" do
+    user = users(:confirmed)
+    params = { user: { password: "newpassword", password_confirmation: "newpassword", current_password: "password123" } }
+
+    sign_in_as(user)
+    patch profile_password_url, params: params
+
+    assert_redirected_to profile_url
+    assert_equal "Password updated", flash[:notice]
+    assert user.reload.authenticate("newpassword")
+  end
+
+  test "#update_password will not change password when current_password is incorrect" do
+    user = users(:confirmed)
+    params = { user: { password: "newpassword", password_confirmation: "newpassword2", current_password: "wrongpassword" } }
+
+    sign_in_as(user)
+    patch profile_password_url, params: params
+
+    assert_response :unprocessable_entity
+    assert_not user.reload.authenticate("newpassword")
+  end
+
+  test "#update_password will not change password when password and password_confirmation do not match" do
+    user = users(:confirmed)
+    params = { user: { password: "newpassword", password_confirmation: "notnewpassword", current_password: "password123" } }
+
+    sign_in_as(user)
+    patch profile_password_url, params: params
+
+    assert_response :unprocessable_entity
+    assert_not user.reload.authenticate("newpassword")
   end
 end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
     get new_registration_url
+
     assert_response :success
   end
 
@@ -32,6 +33,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
           password_confirmation: "password123"
         }
       }
+
     assert_response :unprocessable_entity
     assert response.body.include?("Email address is invalid")
   end
@@ -44,6 +46,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
           password_confirmation: "password123"
         }
       }
+
     assert_response :unprocessable_entity
     assert response.body.include?("Username is too short (minimum is 7 characters)")
   end
@@ -56,6 +59,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
           password_confirmation: "password123"
         }
       }
+
     assert_response :unprocessable_entity
     assert response.body.include?("Password is too short (minimum is 10 characters)")
   end
@@ -68,13 +72,15 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
           password_confirmation: "123password"
         }
       }
+
     assert_response :unprocessable_entity
     assert response.parsed_body.to_html.include?("Password confirmation doesn't match Password")
   end
 
   test "confirm a successful email confirmation" do
-    user = users(:one)
+    user = users(:confirmed)
     orignal_confirmed_at = user.confirmed_at
+
     get confirm_registrations_url(user.generate_token_for(:email_confirmation))
 
     assert_redirected_to new_session_url

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -11,8 +11,8 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert_emails 1 do
       post registrations_url, params: {
         user: {
-          email_address: "john.doe.123@example.com",
-          username: "JohnDoe123",
+          email_address: "new.user@example.com",
+          username: "NewUser123",
           password: "password123",
           password_confirmation: "password123"
         }
@@ -21,14 +21,14 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_url
     assert_equal "You have successfully registered! Please check your email to confirm your email address.", flash[:notice]
-    assert_not_nil User.find_by(email_address: "john.doe.123@example.com")
+    assert_not_nil User.find_by(email_address: "new.user@example.com")
   end
 
   test "should show an error message when email address is invalid" do
     post registrations_url, params: {
         user: {
-          email_address: "john.doe.123",
-          username: "JohnDoe123",
+          email_address: "new.user",
+          username: "NewUser123",
           password: "password123",
           password_confirmation: "password123"
         }
@@ -41,7 +41,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "should show an error message when username is invalid" do
     post registrations_url, params: {
         user: {
-          email_address: "john.doe.123@example.com",
+          email_address: "new.user@example.com",
           password: "password123",
           password_confirmation: "password123"
         }
@@ -54,7 +54,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "should show an error message when password is invalid" do
     post registrations_url, params: {
         user: {
-          email_address: "john.doe.123@example.com",
+          email_address: "new.user@example.com",
           password: "password",
           password_confirmation: "password123"
         }
@@ -67,7 +67,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "should show an error message when password_confirmation is invalid" do
     post registrations_url, params: {
         user: {
-          email_address: "john.doe.123@example.com",
+          email_address: "new.user@example.com",
           password: "password123",
           password_confirmation: "123password"
         }

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class SessionsControllerTest < ActionDispatch::IntegrationTest
   test "new" do
     get new_session_url
+
     assert_response :success
   end
 
@@ -30,7 +31,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     post session_url, params: { new_session_form: { email_address: "one@example.com", password: "wrong" } }
 
     assert_redirected_to new_session_url
-    assert_nil parsed_cookies.signed[:session_id]
+    assert_not parsed_cookies.key? :session_id
     assert_equal "Invalid email or password.", flash[:alert]
   end
 
@@ -43,7 +44,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "destroy" do
-    sign_in :confirmed
+    sign_in_as(:unconfirmed)
 
     delete session_url
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -49,7 +49,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     delete session_url
 
     assert_equal response.headers["clear-site-data"], "\"cache\",\"storage\""
-    assert_redirected_to root_url
+    assert_redirected_to new_session_url
     assert_empty cookies[:session_id]
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,5 @@
 <% password_digest = BCrypt::Password.create("password123") %>
 
-one:
-  email_address: one@example.com
-  username: "UserOne123"
-  password_digest: <%= password_digest %>
-  confirmed_at: <%= Time.current %>
-
 confirmed:
   email_address: confirmed@example.com
   username: "ConfirmedUser"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,3 +10,9 @@ unconfirmed:
   email_address: unconfirmed@example.com
   username: "UnconfirmedUser"
   password_digest: <%= password_digest %>
+
+johndoe:
+  email_address: john.doe@example.com
+  username: "JohnDoe123"
+  password_digest: <%= password_digest %>
+  confirmed_at: <%= Time.current %>

--- a/test/mailers/password_mailer_test.rb
+++ b/test/mailers/password_mailer_test.rb
@@ -16,5 +16,23 @@ class PasswordsMailerTest < ActionMailer::TestCase
     assert_equal "Reset your password", email.subject
     assert email.text_part.body.to_s.include? "You can reset your password within the next 15 minutes on this password reset page:"
     assert email.text_part.body.to_s["#{root_url}passwords/"]
+    assert email.html_part.body.to_s.include? "You can reset your password within the next 15 minutes on"
+  end
+
+  test "changed" do
+    user = users(:confirmed)
+    email = PasswordsMailer.changed(user)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [ "from@example.com" ], email.from
+    assert_equal [ user.email_address ], email.to
+    assert_equal "Password Changed", email.subject
+    assert email.text_part.body.to_s.include? "We are emailing you to let you know your password has been changed.are"
+    assert email.text_part.body.to_s.include? "If you did not request this change, please contact us immediately."
+    assert email.html_part.body.to_s.include? "We are emailing you to let you know your password has been changed.are"
+    assert email.html_part.body.to_s.include? "If you did not request this change, please contact us immediately."
   end
 end

--- a/test/mailers/password_mailer_test.rb
+++ b/test/mailers/password_mailer_test.rb
@@ -4,7 +4,7 @@ class PasswordsMailerTest < ActionMailer::TestCase
   include Rails.application.routes.url_helpers
 
   test "reset" do
-    user = users(:one)
+    user = users(:confirmed)
     email = PasswordsMailer.reset(user)
 
     assert_emails 1 do

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -4,7 +4,7 @@ class UserMailerTest < ActionMailer::TestCase
   include Rails.application.routes.url_helpers
 
   test "confirm_email" do
-    @user = users(:one)
+    @user = users(:confirmed)
     mail = UserMailer.confirm_email(@user)
 
     assert_emails 1 do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -31,7 +31,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "username must be unique" do
-    existing_user = users(:one)
+    existing_user = users(:confirmed)
     user = User.new(email_address: "new.email.123@example.com", username: existing_user.username, password: "password123")
 
     assert_not user.valid?
@@ -39,7 +39,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "username is case in-sensitive unique" do
-    existing_user = users(:one)
+    existing_user = users(:confirmed)
     user = User.new(email_address: "new.email.123@example.com", username: existing_user.username.upcase, password: "password123")
 
     assert_not user.valid?
@@ -81,14 +81,14 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "generates_token_for email_confirmation will return the user for a valid token" do
-    user = users(:one)
+    user = users(:confirmed)
     token = user.generate_token_for(:email_confirmation)
 
     assert_equal user.id, User.find_by_token_for(:email_confirmation, token).id
   end
 
   test "generates_token_for email_confirmation will not work if confirmed_at has changed" do
-    user = users(:one)
+    user = users(:confirmed)
     token = user.generate_token_for(:email_confirmation)
     user.update(confirmed_at: Time.current)
 
@@ -96,7 +96,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "generates_token_for email_confirmation will not work if token is expired" do
-    user = users(:one)
+    user = users(:confirmed)
     token = user.generate_token_for(:email_confirmation)
 
     travel_to Time.current + 2.days do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,29 +2,29 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   test "valid user" do
-    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "password123")
+    user = User.new(email_address: "new.user@example.com", username: "NewUser123", password: "password123")
     assert user.valid?
   end
 
   test "valid user with password_confirmation" do
-    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "password123", password_confirmation: "password123")
+    user = User.new(email_address: "new.user@example.com", username: "NewUser123", password: "password123", password_confirmation: "password123")
     assert user.valid?
   end
 
   test "email_address normalization" do
-    user = User.new(email_address: "  John.Doe@EXAMPLE.COM  \n ", username: "JohnDoe123", password: "password123")
-    assert_equal(user.email_address, "john.doe@example.com")
+    user = User.new(email_address: "  new.user@EXAMPLE.COM  \n ", username: "NewUser123", password: "password123")
+    assert_equal(user.email_address, "new.user@example.com")
   end
 
   test "email_address must be valid" do
-    user = User.new(email_address: "not.an.email", username: "JohnDoe123", password: "password123")
+    user = User.new(email_address: "not.an.email", username: "NewUser123", password: "password123")
     assert_not user.valid?
     assert_equal user.errors[:email_address], [ "is invalid" ]
   end
 
   test "email_address must be unique" do
-    User.create(email_address: "John.Doe@EXAMPLE.com", username: "JohnDoe123", password: "password123")
-    other_user = User.new(email_address: "john.doe@example.com", username: "JohnDoe345", password: "password123")
+    User.create(email_address: "new.user@EXAMPLE.com", username: "NewUser123", password: "password123")
+    other_user = User.new(email_address: "new.user@example.com", username: "JohnDoe345", password: "password123")
 
     assert_not other_user.valid?
     assert_equal other_user.errors[:email_address], [ "has already been taken" ]
@@ -47,34 +47,34 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "username must contain only letters and numbers" do
-    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123!", password: "password123")
+    user = User.new(email_address: "new.user@example.com", username: "NewUser123!", password: "password123")
 
     assert_not user.valid?
     assert_equal user.errors[:username], [ "must contain only letters and numbers" ]
   end
 
   test "username will be normalized to strip extra whitespace" do
-    user = User.new(email_address: "john.doe@example.com", username: "  \r\n  JohnDoe123 \n\r  ", password: "password123")
+    user = User.new(email_address: "new.user@example.com", username: "  \r\n  NewUser123 \n\r  ", password: "password123")
 
-    assert_equal(user.username, "JohnDoe123")
+    assert_equal(user.username, "NewUser123")
   end
 
   test "password is required" do
-    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "")
+    user = User.new(email_address: "new.user@example.com", username: "NewUser123", password: "")
 
     assert_not user.valid?
     assert_equal user.errors[:password], [ "can't be blank", "is too short (minimum is 10 characters)" ]
   end
 
   test "password must be at least 10 characters" do
-    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "aaaaaaaaa")
+    user = User.new(email_address: "new.user@example.com", username: "NewUser123", password: "aaaaaaaaa")
 
     assert_not user.valid?
     assert_equal user.errors[:password], [ "is too short (minimum is 10 characters)" ]
   end
 
   test "password must match password_confirmation" do
-    user = User.new(email_address: "john.doe@example.com", username: "JohnDoe123", password: "password123", password_confirmation: "password456")
+    user = User.new(email_address: "new.user@example.com", username: "NewUser123", password: "password123", password_confirmation: "password456")
 
     assert_not user.valid?
     assert_equal user.errors[:password_confirmation], [ "doesn't match Password" ]

--- a/test/system/change_password_test.rb
+++ b/test/system/change_password_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class ChangePasswordTest < ApplicationSystemTestCase
   test "a user can change their password" do
-    sign_in_as(:one)
+    sign_in_as(:confirmed)
 
     visit profile_url
     fill_in "Current password", with: "password123"
@@ -14,7 +14,7 @@ class ChangePasswordTest < ApplicationSystemTestCase
   end
 
   test "a user sees an error message when they try to change their password with invalid password confirmation" do
-    sign_in_as(:one)
+    sign_in_as(:confirmed)
 
     visit profile_url
     fill_in "New password", with: "newpassword"
@@ -26,7 +26,7 @@ class ChangePasswordTest < ApplicationSystemTestCase
   end
 
   test "a user sees an error message when they try to change their password with invalid current password" do
-    sign_in_as(:one)
+    sign_in_as(:confirmed)
 
     visit profile_url
     fill_in "New password", with: "newpassword"

--- a/test/system/change_password_test.rb
+++ b/test/system/change_password_test.rb
@@ -1,0 +1,39 @@
+require "application_system_test_case"
+
+class ChangePasswordTest < ApplicationSystemTestCase
+  test "a user can change their password" do
+    sign_in_as(:one)
+
+    visit profile_url
+    fill_in "Current password", with: "password123"
+    fill_in "New password", with: "newpassword"
+    fill_in "Confirm new password", with: "newpassword"
+    click_on "Change Password"
+
+    assert_text "Password updated"
+  end
+
+  test "a user sees an error message when they try to change their password with invalid password confirmation" do
+    sign_in_as(:one)
+
+    visit profile_url
+    fill_in "New password", with: "newpassword"
+    fill_in "Confirm new password", with: "notnewpassword"
+    fill_in "Current password", with: "password123"
+    click_on "Change Password"
+
+    assert_text "Password confirmation doesn't match Password"
+  end
+
+  test "a user sees an error message when they try to change their password with invalid current password" do
+    sign_in_as(:one)
+
+    visit profile_url
+    fill_in "New password", with: "newpassword"
+    fill_in "Confirm new password", with: "newpassword"
+    fill_in "Current password", with: "notcurrentpassword"
+    click_on "Change Password"
+
+    assert_text "Current password is incorrect"
+  end
+end

--- a/test/system/log_in_test.rb
+++ b/test/system/log_in_test.rb
@@ -2,12 +2,11 @@ require "application_system_test_case"
 
 class LogInTest < ApplicationSystemTestCase
   test "a user can log in" do
-    visit new_session_url
-
     user = users(:unconfirmed)
+
+    visit new_session_url
     fill_in "Email", with: user.email_address
     fill_in "Password", with: "password123"
-
     click_on "Log in"
 
     assert_current_path root_url
@@ -17,20 +16,16 @@ class LogInTest < ApplicationSystemTestCase
 
   test "when a invalid email or password are submitted, they will see an error message" do
     visit new_session_url
-
     fill_in "Email", with: "does.not.exist@example.com"
     fill_in "Password", with: "password123"
-
     click_on "Log in"
 
     assert_current_path new_session_url
-
     assert_text "Invalid email or password"
   end
 
   test "clicking on 'Forgot your password?' will take you to the forgot password page" do
     visit new_session_url
-
     click_on "Forgot your password?"
 
     assert_current_path new_password_url

--- a/test/system/log_out_test.rb
+++ b/test/system/log_out_test.rb
@@ -2,10 +2,8 @@ require "application_system_test_case"
 
 class LogOutTest < ApplicationSystemTestCase
   test "a user can log out" do
-    user = users(:confirmed)
-    sign_in_as(user)
-
-    assert_text "Logout"
+    sign_in_as(:confirmed)
+    visit root_url
     click_on "Logout"
 
     assert_current_path root_url

--- a/test/system/log_out_test.rb
+++ b/test/system/log_out_test.rb
@@ -6,8 +6,6 @@ class LogOutTest < ApplicationSystemTestCase
     visit root_url
     click_on "Logout"
 
-    assert_current_path root_url
-    assert_text "Login"
-    assert_text "Register"
+    assert_current_path new_session_url
   end
 end

--- a/test/system/password_reset_test.rb
+++ b/test/system/password_reset_test.rb
@@ -13,8 +13,8 @@ class PasswordResetTest < ApplicationSystemTestCase
 
   test "a user can reset their password when they have a valid token" do
     user = users(:confirmed)
-    visit edit_password_url(user.generate_token_for(:password_reset))
 
+    visit edit_password_url(user.generate_token_for(:password_reset))
     fill_in "New Password", with: "new_password"
     fill_in "Confirm New Password", with: "new_password"
     click_on "Save New Password"
@@ -32,8 +32,8 @@ class PasswordResetTest < ApplicationSystemTestCase
 
   test "a user cannot reset their password when the password and password confirmation does not match" do
     token = users(:confirmed).generate_token_for(:password_reset)
-    visit edit_password_url(token)
 
+    visit edit_password_url(token)
     fill_in "New Password", with: "new_password"
     fill_in "Confirm New Password", with: "NOT_new_password"
     click_on "Save New Password"

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -15,7 +15,7 @@ class ProfileTest < ApplicationSystemTestCase
   test "a user sees an error message when they try to update their profile with invalid data" do
     existing_user = users(:confirmed)
 
-    sign_in_as(:one)
+    sign_in_as(:confirmed)
     visit profile_url
     fill_in "Email", with: existing_user.email_address
     fill_in "Username", with: "!!not_valid_username!!"

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -13,7 +13,7 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "a user sees an error message when they try to update their profile with invalid data" do
-    existing_user = users(:confirmed)
+    existing_user = users(:johndoe)
 
     sign_in_as(:confirmed)
     visit profile_url

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -2,9 +2,7 @@ require "application_system_test_case"
 
 class ProfileTest < ApplicationSystemTestCase
   test "a user can update their profile" do
-    user = users(:one)
-    sign_in_as(user)
-
+    sign_in_as(:confirmed)
     visit profile_url
     fill_in "Email", with: "john.doe.2@example.com"
     fill_in "Username", with: "JohnDoe2"
@@ -15,10 +13,9 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "a user sees an error message when they try to update their profile with invalid data" do
-    user = users(:one)
     existing_user = users(:confirmed)
-    sign_in_as(user)
 
+    sign_in_as(:one)
     visit profile_url
     fill_in "Email", with: existing_user.email_address
     fill_in "Username", with: "!!not_valid_username!!"
@@ -32,8 +29,8 @@ class ProfileTest < ApplicationSystemTestCase
   test "an unconfirmed user cannot update their profile" do
     user = users(:unconfirmed)
     params = { email_address: "different.email@example.com", username: "DifferentUsername" }
-    sign_in_as(user)
 
+    sign_in_as(user)
     visit profile_url
     fill_in "Email", with: params[:email_address]
     fill_in "Username", with: params[:username]
@@ -47,9 +44,7 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "an unconfirmed user will see 'Pending confirmation' on their profile" do
-    user = users(:unconfirmed)
-    sign_in_as(user)
-
+    sign_in_as(:unconfirmed)
     visit profile_url
 
     assert_current_path profile_url
@@ -57,9 +52,9 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "a confirmed user will see email confirmation date on their profile" do
-    user = users(:one)
-    sign_in_as(user)
+    user = users(:confirmed)
 
+    sign_in_as(user)
     visit profile_url
 
     assert_current_path profile_url

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -4,8 +4,8 @@ class RegistrationsTest < ApplicationSystemTestCase
   test "registering a new user" do
     visit new_registration_url
 
-    fill_in "Email", with: "john.doe@example.com"
-    fill_in "Username", with: "JohnDoe123"
+    fill_in "Email", with: "new.user@example.com"
+    fill_in "Username", with: "NewUser123"
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "password123"
 
@@ -18,8 +18,8 @@ class RegistrationsTest < ApplicationSystemTestCase
   test "when password and password confirmation do not match, it will display the error message" do
     visit new_registration_url
 
-    fill_in "Email", with: "john.doe@example.com"
-    fill_in "Username", with: "JohnDoe123"
+    fill_in "Email", with: "new.user@example.com"
+    fill_in "Username", with: "NewUser123"
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "NOT_password123"
 
@@ -33,7 +33,7 @@ class RegistrationsTest < ApplicationSystemTestCase
     visit new_registration_url
 
     fill_in "Email", with: users(:confirmed).email_address
-    fill_in "Username", with: "JohnDoe123"
+    fill_in "Username", with: "NewUser123"
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "password123"
 
@@ -46,7 +46,7 @@ class RegistrationsTest < ApplicationSystemTestCase
   test "when an existing username is used, it will display the error message" do
     visit new_registration_url
 
-    fill_in "Email", with: "john.doe@example.com"
+    fill_in "Email", with: "new.user@example.com"
     fill_in "Username", with: users(:confirmed).username
     fill_in "Password", with: "password123"
     fill_in "Confirm password", with: "password123"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,9 +14,9 @@ module ActiveSupport
     #
     # @param user [User, Symbol] the user to sign in, or a symbol representing a user fixture
     # @return [void]
-    def sign_in(user)
+    def sign_in_as(user, password: "password123")
       user = users(user) unless user.is_a? User
-      post session_path, params: { new_session_form: { email_address: user.email_address, password: "password123" } }
+      post session_path, params: { new_session_form: { email_address: user.email_address, password: } }
     end
 
     # Signs out the current user by deleting the session.


### PR DESCRIPTION
Added the ability for a user to reset their password via their profile.

Additionally made tweaks to testing and fixtures.

Resolves #48 