### PR TITLE
Moved email to it's own section within the profile page

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,5 +1,5 @@
 class ProfileController < ApplicationController
-  before_action :require_email_confirmation, only: :update
+  before_action :require_email_confirmation, only: [ :update, :update_email ]
 
   def index
   end
@@ -7,6 +7,14 @@ class ProfileController < ApplicationController
   def update
     if current_user.update(update_profile_params)
       redirect_to profile_path, notice: "Profile updated"
+    else
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  def update_email
+    if current_user.update(update_email_params)
+      redirect_to profile_path, notice: "Email address updated"
     else
       render :index, status: :unprocessable_entity
     end
@@ -30,8 +38,13 @@ class ProfileController < ApplicationController
   private
 
   def update_profile_params
-    params.expect(user: [ :username, :email_address ])
-      .with_defaults(username: "", email_address: "")
+    params.expect(user: [ :username ])
+      .with_defaults(username: "")
+  end
+
+  def update_email_params
+    params.expect(user: [ :email_address ])
+      .with_defaults(email_address: "")
   end
 
   def update_password_params

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -11,25 +11,6 @@
   <div class="col-span-4 lg:col-span-3">
     <%= form_for current_user, url: profile_path do |form| %>
       <div class="mb-6">
-        <div class="flex items-center justify-between">
-          <%= form.label :email_address, "Email" %>
-
-          <% if current_user.confirmed_at.present? %>
-            <span title="<%= current_user.confirmed_at %>" class="text-gray-500 text-sm mt-1">Confirmed at <%= current_user.confirmed_at.strftime('%m/%d/%Y') %></span>
-          <% else %>
-            <span class="text-red-500 text-sm mt-1">Pending confirmation</p>
-          <% end %>
-        </div>
-        <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "email", value: current_user.email_address, class: "form-text" %>
-
-        <% if current_user.errors[:email_address].any? %>
-          <p class="text-red-500 text-sm mt-1">
-            <%= current_user.errors.full_messages_for(:email_address).first %>
-          </p>
-        <% end %>
-      </div>
-
-      <div class="mb-6">
         <%= form.label :username, "Username" %>
         <%= form.text_field :username, required: true, autocomplete: "username", value: current_user.username, class: "form-text" %>
 
@@ -42,6 +23,42 @@
 
       <div class="flex items-center justify-end">
         <%= form.submit "Update Profile", class: "form-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="md:grid md:grid-cols-6 md:gap-4 p-4 sm:p-8 bg-white shadow sm:rounded-md">
+  <div class="col-span-2 mb-8 md:mb-0">
+    <h2 class="text-lg font-medium text-gray-900">
+      Change Email
+    </h2>
+    <p class="mt-1 text-sm text-gray-600">
+      This will require confirming your new email address.
+    </p>
+  </div>
+
+  <div class="col-span-4 lg:col-span-3">
+    <%= form_for current_user, url: profile_email_path do |form| %>
+      <div class="mb-6">
+        <div class="flex items-center justify-between">
+          <%= form.label :email_address, "Email" %>
+
+          <% if current_user.confirmed_at.present? %>
+            <span title="<%= current_user.confirmed_at %>" class="text-gray-500 text-sm mt-1">Confirmed at <%= current_user.confirmed_at.strftime('%m/%d/%Y') %></span>
+          <% end %>
+        </div>
+        <%= form.text_field :email_address, required: true, autofocus: false, autocomplete: "email", value: current_user.email_address, class: "form-text" %>
+
+        <% if current_user.errors[:email_address].any? %>
+          <p class="text-red-500 text-sm mt-1">
+            <%= current_user.errors.full_messages_for(:email_address).first %>
+          </p>
+        <% end %>
+      </div>
+
+      <div class="flex items-center justify-end">
+        <%= form.submit "Change Email", class: "form-button" %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get "profile" => "profile#index", as: :profile
   patch "profile" => "profile#update"
   patch "profile/password" => "profile#update_password", as: :profile_password
+  patch "profile/email" => "profile#update_email", as: :profile_email
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/test/controllers/profile_controller_test.rb
+++ b/test/controllers/profile_controller_test.rb
@@ -11,7 +11,7 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
 
   test "#update updates the user" do
     user = users(:confirmed)
-    params = { user: { username: "newusername", email_address: "new.email@example.com" } }
+    params = { user: { username: "newusername" } }
 
     sign_in_as(user)
     patch profile_url, params: params
@@ -20,11 +20,10 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to profile_url
     assert_equal "Profile updated", flash[:notice]
     assert_equal params[:user][:username], user.username
-    assert_equal params[:user][:email_address], user.email_address
   end
 
   test "#update with render :index when user is invalid" do
-    params = { user: { email_address: "new.email@example.com" } }
+    params = { user: { username: "bad.username!" } }
 
     sign_in_as(:confirmed)
     patch profile_url, params: params
@@ -34,7 +33,7 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
 
   test "#update requires email confirmation" do
     user = users(:unconfirmed)
-    params = { user: { email_address: "different.email@example.com", username: "DifferentUsername" } }
+    params = { user: { username: "DifferentUsername" } }
 
     sign_in_as(user)
     patch profile_url, params: params
@@ -43,7 +42,39 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to profile_url
     assert_equal "Email address not confirmed. Please check your email for a confirmation link.", flash[:alert]
     assert_not_equal params[:user][:username], user.username
-    assert_not_equal params[:user][:email_address], user.email_address
+  end
+
+  test "#update_email updates the user's email address" do
+    user = users(:confirmed)
+    params = { user: { email_address: "new.email@example.com" } }
+
+    sign_in_as(user)
+    patch profile_email_url, params: params
+
+    assert_redirected_to profile_url
+    assert_equal "Email address updated", flash[:notice]
+    assert_equal params[:user][:email_address], user.reload.email_address
+  end
+
+  test "#update_email with render :index when user is invalid" do
+    params = { user: { email_address: "" } }
+
+    sign_in_as(:confirmed)
+    patch profile_email_url, params: params
+
+    assert_response :unprocessable_entity
+  end
+
+  test "#update_email requires confirmed email" do
+  user = users(:unconfirmed)
+  params = { user: { email_address: "new.email@example.com" } }
+
+  sign_in_as(user)
+  patch profile_email_url, params: params
+
+  assert_redirected_to profile_url
+  assert_equal "Email address not confirmed. Please check your email for a confirmation link.", flash[:alert]
+  assert_not_equal params[:user][:email_address], user.reload.email_address
   end
 
   test "#update_password updates the user's password" do

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -4,7 +4,6 @@ class ProfileTest < ApplicationSystemTestCase
   test "a user can update their profile" do
     sign_in_as(:confirmed)
     visit profile_url
-    fill_in "Email", with: "john.doe.2@example.com"
     fill_in "Username", with: "JohnDoe2"
     click_on "Update Profile"
 
@@ -13,42 +12,13 @@ class ProfileTest < ApplicationSystemTestCase
   end
 
   test "a user sees an error message when they try to update their profile with invalid data" do
-    existing_user = users(:johndoe)
-
     sign_in_as(:confirmed)
     visit profile_url
-    fill_in "Email", with: existing_user.email_address
     fill_in "Username", with: "!!not_valid_username!!"
     click_on "Update Profile"
 
     assert_current_path profile_url
-    assert_text "Email address has already been taken"
     assert_text "Username must contain only letters and numbers"
-  end
-
-  test "an unconfirmed user cannot update their profile" do
-    user = users(:unconfirmed)
-    params = { email_address: "different.email@example.com", username: "DifferentUsername" }
-
-    sign_in_as(user)
-    visit profile_url
-    fill_in "Email", with: params[:email_address]
-    fill_in "Username", with: params[:username]
-    click_on "Update Profile"
-    user.reload
-
-    assert_current_path profile_url
-    assert_text "Email address not confirmed. Please check your email for a confirmation link."
-    assert_not_equal params[:username], user.username
-    assert_not_equal params[:email_address], user.email_address
-  end
-
-  test "an unconfirmed user will see 'Pending confirmation' on their profile" do
-    sign_in_as(:unconfirmed)
-    visit profile_url
-
-    assert_current_path profile_url
-    assert_text "Pending confirmation"
   end
 
   test "a confirmed user will see email confirmation date on their profile" do
@@ -59,5 +29,25 @@ class ProfileTest < ApplicationSystemTestCase
 
     assert_current_path profile_url
     assert_text "Confirmed at #{user.confirmed_at.strftime('%m/%d/%Y')}"
+  end
+
+  test "a user can update their email address" do
+    sign_in_as(:confirmed)
+    visit profile_url
+    fill_in "Email", with: "new.email@example.com"
+    click_on "Change Email"
+
+    assert_current_path profile_url
+    assert_text "Email address updated"
+  end
+
+  test "a user sees an error message when they try to update their email address with invalid data" do
+    sign_in_as(:confirmed)
+    visit profile_url
+    fill_in "Email", with: "bad!email!example.com"
+    click_on "Change Email"
+
+    assert_current_path profile_url
+    assert_text "Email address is invalid"
   end
 end


### PR DESCRIPTION
This pull request moves the email to it's own section within the `/profile` page. This will help with future change email work in the future.

Resolves #59 