### PR TITLE
Added the ability for an unconfirmed user to resend the confirmation

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -20,6 +20,16 @@ class ProfileController < ApplicationController
     end
   end
 
+  def send_email_confirmation
+    if current_user.confirmed_at?
+      return redirect_to profile_path, alert: "Email address already confirmed."
+    end
+
+    UserMailer.confirm_email(current_user).deliver_later
+
+    redirect_to profile_path, notice: "Confirmation email sent. Please check your email."
+  end
+
   def update_password
     unless current_user.authenticate(params[:user][:current_password])
       current_user.errors.add(:current_password, "is incorrect")

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -34,31 +34,38 @@
       Change Email
     </h2>
     <p class="mt-1 text-sm text-gray-600">
-      This will require confirming your new email address.
+      Changing your email will require confirming your new email address.
     </p>
   </div>
 
   <div class="col-span-4 lg:col-span-3">
-    <%= form_for current_user, url: profile_email_path do |form| %>
-      <div class="mb-6">
-        <div class="flex items-center justify-between">
-          <%= form.label :email_address, "Email" %>
+    <% if current_user.confirmed_at? %>
+      <%= form_for current_user, url: profile_email_path do |form| %>
+        <div class="mb-6">
+          <div class="flex items-center justify-between">
+            <%= form.label :email_address, "Email" %>
 
-          <% if current_user.confirmed_at.present? %>
-            <span title="<%= current_user.confirmed_at %>" class="text-gray-500 text-sm mt-1">Confirmed at <%= current_user.confirmed_at.strftime('%m/%d/%Y') %></span>
+            <% if current_user.confirmed_at.present? %>
+              <span title="<%= current_user.confirmed_at %>" class="text-gray-500 text-sm mt-1">Confirmed at <%= current_user.confirmed_at.strftime('%m/%d/%Y') %></span>
+            <% end %>
+          </div>
+          <%= form.text_field :email_address, required: true, autofocus: false, autocomplete: "email", value: current_user.email_address, class: "form-text" %>
+
+          <% if current_user.errors[:email_address].any? %>
+            <p class="text-red-500 text-sm mt-1">
+              <%= current_user.errors.full_messages_for(:email_address).first %>
+            </p>
           <% end %>
         </div>
-        <%= form.text_field :email_address, required: true, autofocus: false, autocomplete: "email", value: current_user.email_address, class: "form-text" %>
 
-        <% if current_user.errors[:email_address].any? %>
-          <p class="text-red-500 text-sm mt-1">
-            <%= current_user.errors.full_messages_for(:email_address).first %>
-          </p>
-        <% end %>
-      </div>
-
+        <div class="flex items-center justify-end">
+          <%= form.submit "Change Email", class: "form-button" %>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="mb-6 text-sm text-gray-600">Your email has not yet been confirmed. Please check your email and confirm your email address. If you need to resend the confirmation email, you can do so below.</p>
       <div class="flex items-center justify-end">
-        <%= form.submit "Change Email", class: "form-button" %>
+        <%= button_to "Resend confirmation email", profile_send_email_confirmation_path, method: :patch, class: "form-button" %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   patch "profile" => "profile#update"
   patch "profile/password" => "profile#update_password", as: :profile_password
   patch "profile/email" => "profile#update_email", as: :profile_email
+  patch "profile/email/send_confirmation" => "profile#send_email_confirmation", as: :profile_send_email_confirmation
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/test/controllers/profile_controller_test.rb
+++ b/test/controllers/profile_controller_test.rb
@@ -77,6 +77,26 @@ class ProfileControllerTest < ActionDispatch::IntegrationTest
   assert_not_equal params[:user][:email_address], user.reload.email_address
   end
 
+  test "#send_email_confirmation sends a confirmation email" do
+    sign_in_as(:unconfirmed)
+    assert_enqueued_emails 1 do
+      patch profile_send_email_confirmation_url
+    end
+
+    assert_redirected_to profile_url
+    assert_equal "Confirmation email sent. Please check your email.", flash[:notice]
+  end
+
+  test "#send_email_confirmation does not send a confirmation email if the email is already confirmed" do
+    sign_in_as(:confirmed)
+    assert_no_enqueued_emails do
+      patch profile_send_email_confirmation_url
+    end
+
+    assert_redirected_to profile_url
+    assert_equal "Email address already confirmed.", flash[:alert]
+  end
+
   test "#update_password updates the user's password" do
     user = users(:confirmed)
     params = { user: { password: "newpassword", password_confirmation: "newpassword", current_password: "password123" } }

--- a/test/system/profile_test.rb
+++ b/test/system/profile_test.rb
@@ -50,4 +50,13 @@ class ProfileTest < ApplicationSystemTestCase
     assert_current_path profile_url
     assert_text "Email address is invalid"
   end
+
+  test "an unconfirmed user can request a new confirmation email" do
+    sign_in_as(:unconfirmed)
+    visit profile_url
+    click_on "Resend confirmation email"
+
+    assert_current_path profile_url
+    assert_text "Confirmation email sent. Please check your email."
+  end
 end


### PR DESCRIPTION
This pull request adds the ability for an unconfirmed user to request the confirmation email to be resent.

Resolves #41 