### PR TITLE
Removed Clear-Site-Data header from SessionsController#destroy

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,6 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
-    clear_site_data
     redirect_to new_session_path
   end
 
@@ -37,9 +36,5 @@ class SessionsController < ApplicationController
     return false unless params[:new_session_form].key?(:remember_me)
 
     params[:new_session_form][:remember_me] == "1"
-  end
-
-  def clear_site_data
-    response.headers["Clear-Site-Data"] = '"cache","storage"'
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -48,7 +48,6 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     delete session_url
 
-    assert_equal response.headers["clear-site-data"], "\"cache\",\"storage\""
     assert_redirected_to new_session_url
     assert_empty cookies[:session_id]
   end


### PR DESCRIPTION
This pull request removes the `Clear-Site-Data` header during log out. This was causing the response (browser-side) to take 3 to 15 seconds.

Resolves #68 