### PR TITLE
Destroyed all sessions for the user after successful password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -20,6 +20,7 @@ class PasswordsController < ApplicationController
 
   def update
     if @user.update(update_password_params.merge(confirmed_at: Time.current))
+      @user.sessions.destroy_all
       return redirect_to new_session_path, notice: "Your password has been reset. You may now log in."
     end
 

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -45,6 +45,15 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal old_confirmed_at, user.reload.confirmed_at
   end
 
+  test "the users sessions are destroyed when the password is updated" do
+    user = users(:confirmed)
+    user.sessions.create
+
+    patch password_url(user.password_reset_token), params: { user: { password: "newpassword", password_confirmation: "newpassword" } }
+
+    assert_empty user.reload.sessions
+  end
+
   test "a password cannot be updated with invalid token" do
     user = users(:confirmed)
 


### PR DESCRIPTION
This pull request updates the password reset flow to destroy all sessions for the user after successfully resetting their password.

Resolves #79